### PR TITLE
PoWA - Update links

### DIFF
--- a/powa/build_all.sh
+++ b/powa/build_all.sh
@@ -15,8 +15,8 @@ echo "######################"
 # get a X.Y.Z information from the latest release name, which should be
 # "version X.Y.Z". The releanse name can be easily edited, so this should be
 # more reliable than using the release tags.
-ARCHIVIST="$(wget -O- https://api.github.com/repos/dalibo/powa-archivist/releases/latest | jq -r '.name' | sed 's/version //')"
-WEB="$(wget -O- https://api.github.com/repos/dalibo/powa-web/releases/latest | jq -r '.name' | sed 's/version //')"
+ARCHIVIST="$(wget -O- https://api.github.com/repos/powa-team/powa-archivist/releases/latest | jq -r '.name' | sed 's/version //')"
+WEB="$(wget -O- https://api.github.com/repos/powa-team/powa-web/releases/latest | jq -r '.name' | sed 's/version //')"
 
 function rmi {
     image="$1"
@@ -64,13 +64,13 @@ for version in $(ls "$BASEDIR" | egrep '[0-9]+\.[0-9]+'); do
     v=$(echo "$version" | sed 's/\.//')
     CURDIR="$BASEDIR/$version"
 
-    rmi "dalibo/powa-archivist-$version:latest"
-    rmi "dalibo/powa-archivist-$version:$ARCHIVIST"
+    rmi "powa-team/powa-archivist-$version:latest"
+    rmi "powa-team/powa-archivist-$version:$ARCHIVIST"
 
     echo "Building powa-archivist tag $ARCHIVIST..."
-    docker build -q --no-cache -t dalibo/powa-archivist-$v:$ARCHIVIST $CURDIR
+    docker build -q --no-cache -t powa-team/powa-archivist-$v:$ARCHIVIST $CURDIR
     echo "Updating powa-archivist:latest..."
-    docker build -q -t dalibo/powa-archivist-$v:latest $CURDIR
+    docker build -q -t powa-team/powa-archivist-$v:latest $CURDIR
 done
 
 echo ""
@@ -83,13 +83,13 @@ echo ""
 echo "Removing old images..."
 
 BASEDIR="$dir/powa-web"
-rmi "dalibo/powa-web:latest"
-rmi "dalibo/powa-web:$WEB"
+rmi "powa-team/powa-web:latest"
+rmi "powa-team/powa-web:$WEB"
 
 echo "Building powa-web tag $WEB..."
-docker build -q --no-cache -t dalibo/powa-web:$WEB $BASEDIR
+docker build -q --no-cache -t powa-team/powa-web:$WEB $BASEDIR
 echo "Updating powa-web:latest..."
-docker build -q -t dalibo/powa-web:latest $BASEDIR
+docker build -q -t powa-team/powa-web:latest $BASEDIR
 
 echo ""
 echo "Done!"

--- a/powa/compose/docker-compose-96.yml
+++ b/powa/compose/docker-compose-96.yml
@@ -1,9 +1,9 @@
 powa-archivist:
-  image: dalibo/powa-archivist-96:latest
+  image: powa-team/powa-archivist-96:latest
   ports:
    - "5432:5432"
 powa-web:
-  image: dalibo/powa-web:latest
+  image: powa-team/powa-web:latest
   ports:
    - "8888:8888"
   links:

--- a/powa/powa-archivist/9.4/Dockerfile
+++ b/powa/powa-archivist/9.4/Dockerfile
@@ -11,10 +11,10 @@ RUN apt-get update && apt-get install -y \
     postgresql-contrib-9.4 \
     postgresql-server-dev-9.4 \
     wget \
-    && wget -O- $(wget -O- https://api.github.com/repos/dalibo/powa-archivist/releases/latest|jq -r '.tarball_url') | tar -xzf - \
-    && wget -O- $(wget -O- https://api.github.com/repos/dalibo/pg_qualstats/releases/latest|jq -r '.tarball_url') | tar -xzf - \
-    && wget -O- $(wget -O- https://api.github.com/repos/dalibo/pg_stat_kcache/releases/latest|jq -r '.tarball_url') | tar -xzf - \
-    && wget -O- $(wget -O- https://api.github.com/repos/dalibo/hypopg/releases/latest|jq -r '.tarball_url') | tar -xzf - \
+    && wget -O- $(wget -O- https://api.github.com/repos/powa-team/powa-archivist/releases/latest|jq -r '.tarball_url') | tar -xzf - \
+    && wget -O- $(wget -O- https://api.github.com/repos/powa-team/pg_qualstats/releases/latest|jq -r '.tarball_url') | tar -xzf - \
+    && wget -O- $(wget -O- https://api.github.com/repos/powa-team/pg_stat_kcache/releases/latest|jq -r '.tarball_url') | tar -xzf - \
+    && wget -O- $(wget -O- https://api.github.com/repos/HypoPG/hypopg/releases/latest|jq -r '.tarball_url') | tar -xzf - \
     && wget -O- $(wget -O- https://api.github.com/repos/rjuju/pg_track_settings/releases/latest|jq -r '.tarball_url') | tar -xzf - \
     && for f in $(ls); do cd $f; make install; cd ..; rm -rf $f; done \
     && apt-get purge -y --auto-remove gcc jq make postgresql-server-dev-9.4 wget \

--- a/powa/powa-archivist/9.4/setup_powa-archivist.sh
+++ b/powa/powa-archivist/9.4/setup_powa-archivist.sh
@@ -2,11 +2,11 @@
 set -e
 
 # Configure shared_preload_libraries
-gosu postgres echo "shared_preload_libraries = 'pg_stat_statements,powa,pg_qualstats,pg_stat_kcache'" >> $PGDATA/postgresql.conf
-gosu postgres echo "listen_addresses = '*'" >> $PGDATA/postgresql.conf
+echo "shared_preload_libraries = 'pg_stat_statements,powa,pg_qualstats,pg_stat_kcache'" >> $PGDATA/postgresql.conf
+echo "listen_addresses = '*'" >> $PGDATA/postgresql.conf
 
 # restart pg
-gosu postgres pg_ctl -D "$PGDATA" -w stop -m fast
-gosu postgres pg_ctl -D "$PGDATA" -w start
+pg_ctl -D "$PGDATA" -w stop -m fast
+pg_ctl -D "$PGDATA" -w start
 
-gosu postgres psql -f /usr/local/src/install_all.sql
+psql -f /usr/local/src/install_all.sql

--- a/powa/powa-archivist/9.5/Dockerfile
+++ b/powa/powa-archivist/9.5/Dockerfile
@@ -11,10 +11,10 @@ RUN apt-get update && apt-get install -y \
     postgresql-contrib-9.5 \
     postgresql-server-dev-9.5 \
     wget \
-    && wget -O- $(wget -O- https://api.github.com/repos/dalibo/powa-archivist/releases/latest|jq -r '.tarball_url') | tar -xzf - \
-    && wget -O- $(wget -O- https://api.github.com/repos/dalibo/pg_qualstats/releases/latest|jq -r '.tarball_url') | tar -xzf - \
-    && wget -O- $(wget -O- https://api.github.com/repos/dalibo/pg_stat_kcache/releases/latest|jq -r '.tarball_url') | tar -xzf - \
-    && wget -O- $(wget -O- https://api.github.com/repos/dalibo/hypopg/releases/latest|jq -r '.tarball_url') | tar -xzf - \
+    && wget -O- $(wget -O- https://api.github.com/repos/powa-team/powa-archivist/releases/latest|jq -r '.tarball_url') | tar -xzf - \
+    && wget -O- $(wget -O- https://api.github.com/repos/powa-team/pg_qualstats/releases/latest|jq -r '.tarball_url') | tar -xzf - \
+    && wget -O- $(wget -O- https://api.github.com/repos/powa-team/pg_stat_kcache/releases/latest|jq -r '.tarball_url') | tar -xzf - \
+    && wget -O- $(wget -O- https://api.github.com/repos/HypoPG/hypopg/releases/latest|jq -r '.tarball_url') | tar -xzf - \
     && wget -O- $(wget -O- https://api.github.com/repos/rjuju/pg_track_settings/releases/latest|jq -r '.tarball_url') | tar -xzf - \
     && for f in $(ls); do cd $f; make install; cd ..; rm -rf $f; done \
     && apt-get purge -y --auto-remove gcc jq make postgresql-server-dev-9.5 wget \

--- a/powa/powa-archivist/9.5/setup_powa-archivist.sh
+++ b/powa/powa-archivist/9.5/setup_powa-archivist.sh
@@ -2,11 +2,11 @@
 set -e
 
 # Configure shared_preload_libraries
-gosu postgres echo "shared_preload_libraries = 'pg_stat_statements,powa,pg_qualstats,pg_stat_kcache'" >> $PGDATA/postgresql.conf
-gosu postgres echo "listen_addresses = '*'" >> $PGDATA/postgresql.conf
+echo "shared_preload_libraries = 'pg_stat_statements,powa,pg_qualstats,pg_stat_kcache'" >> $PGDATA/postgresql.conf
+echo "listen_addresses = '*'" >> $PGDATA/postgresql.conf
 
 # restart pg
-gosu postgres pg_ctl -D "$PGDATA" -w stop -m fast
-gosu postgres pg_ctl -D "$PGDATA" -w start
+pg_ctl -D "$PGDATA" -w stop -m fast
+pg_ctl -D "$PGDATA" -w start
 
-gosu postgres psql -f /usr/local/src/install_all.sql
+psql -f /usr/local/src/install_all.sql

--- a/powa/powa-archivist/9.6/Dockerfile
+++ b/powa/powa-archivist/9.6/Dockerfile
@@ -11,10 +11,10 @@ RUN apt-get update && apt-get install -y \
     postgresql-contrib-9.6 \
     postgresql-server-dev-9.6 \
     wget \
-    && wget -O- $(wget -O- https://api.github.com/repos/dalibo/powa-archivist/releases/latest|jq -r '.tarball_url') | tar -xzf - \
-    && wget -O- $(wget -O- https://api.github.com/repos/dalibo/pg_qualstats/releases/latest|jq -r '.tarball_url') | tar -xzf - \
-    && wget -O- $(wget -O- https://api.github.com/repos/dalibo/pg_stat_kcache/releases/latest|jq -r '.tarball_url') | tar -xzf - \
-    && wget -O- $(wget -O- https://api.github.com/repos/dalibo/hypopg/releases/latest|jq -r '.tarball_url') | tar -xzf - \
+    && wget -O- $(wget -O- https://api.github.com/repos/powa-team/powa-archivist/releases/latest|jq -r '.tarball_url') | tar -xzf - \
+    && wget -O- $(wget -O- https://api.github.com/repos/powa-team/pg_qualstats/releases/latest|jq -r '.tarball_url') | tar -xzf - \
+    && wget -O- $(wget -O- https://api.github.com/repos/powa-team/pg_stat_kcache/releases/latest|jq -r '.tarball_url') | tar -xzf - \
+    && wget -O- $(wget -O- https://api.github.com/repos/HypoPG/hypopg/releases/latest|jq -r '.tarball_url') | tar -xzf - \
     && wget -O- $(wget -O- https://api.github.com/repos/rjuju/pg_track_settings/releases/latest|jq -r '.tarball_url') | tar -xzf - \
     && for f in $(ls); do cd $f; make install; cd ..; rm -rf $f; done \
     && apt-get purge -y --auto-remove gcc jq make postgresql-server-dev-9.6 wget \

--- a/powa/powa-archivist/9.6/setup_powa-archivist.sh
+++ b/powa/powa-archivist/9.6/setup_powa-archivist.sh
@@ -2,11 +2,11 @@
 set -e
 
 # Configure shared_preload_libraries
-gosu postgres echo "shared_preload_libraries = 'pg_stat_statements,powa,pg_qualstats,pg_stat_kcache'" >> $PGDATA/postgresql.conf
-gosu postgres echo "listen_addresses = '*'" >> $PGDATA/postgresql.conf
+echo "shared_preload_libraries = 'pg_stat_statements,powa,pg_qualstats,pg_stat_kcache'" >> $PGDATA/postgresql.conf
+echo "listen_addresses = '*'" >> $PGDATA/postgresql.conf
 
 # restart pg
-gosu postgres pg_ctl -D "$PGDATA" -w stop -m fast
-gosu postgres pg_ctl -D "$PGDATA" -w start
+pg_ctl -D "$PGDATA" -w stop -m fast
+pg_ctl -D "$PGDATA" -w start
 
-gosu postgres psql -f /usr/local/src/install_all.sql
+psql -f /usr/local/src/install_all.sql

--- a/powa/powa-archivist/Dockerfile.template
+++ b/powa/powa-archivist/Dockerfile.template
@@ -11,10 +11,10 @@ RUN apt-get update && apt-get install -y \
     postgresql-contrib-%%PG_VER%% \
     postgresql-server-dev-%%PG_VER%% \
     wget \
-    && wget -O- $(wget -O- https://api.github.com/repos/dalibo/powa-archivist/releases/latest|jq -r '.tarball_url') | tar -xzf - \
-    && wget -O- $(wget -O- https://api.github.com/repos/dalibo/pg_qualstats/releases/latest|jq -r '.tarball_url') | tar -xzf - \
-    && wget -O- $(wget -O- https://api.github.com/repos/dalibo/pg_stat_kcache/releases/latest|jq -r '.tarball_url') | tar -xzf - \
-    && wget -O- $(wget -O- https://api.github.com/repos/dalibo/hypopg/releases/latest|jq -r '.tarball_url') | tar -xzf - \
+    && wget -O- $(wget -O- https://api.github.com/repos/powa-team/powa-archivist/releases/latest|jq -r '.tarball_url') | tar -xzf - \
+    && wget -O- $(wget -O- https://api.github.com/repos/powa-team/pg_qualstats/releases/latest|jq -r '.tarball_url') | tar -xzf - \
+    && wget -O- $(wget -O- https://api.github.com/repos/powa-team/pg_stat_kcache/releases/latest|jq -r '.tarball_url') | tar -xzf - \
+    && wget -O- $(wget -O- https://api.github.com/repos/HypoPG/hypopg/releases/latest|jq -r '.tarball_url') | tar -xzf - \
     && wget -O- $(wget -O- https://api.github.com/repos/rjuju/pg_track_settings/releases/latest|jq -r '.tarball_url') | tar -xzf - \
     && for f in $(ls); do cd $f; make install; cd ..; rm -rf $f; done \
     && apt-get purge -y --auto-remove gcc jq make postgresql-server-dev-%%PG_VER%% wget \

--- a/powa/powa-archivist/setup_powa-archivist.sh
+++ b/powa/powa-archivist/setup_powa-archivist.sh
@@ -2,11 +2,11 @@
 set -e
 
 # Configure shared_preload_libraries
-gosu postgres echo "shared_preload_libraries = 'pg_stat_statements,powa,pg_qualstats,pg_stat_kcache'" >> $PGDATA/postgresql.conf
-gosu postgres echo "listen_addresses = '*'" >> $PGDATA/postgresql.conf
+echo "shared_preload_libraries = 'pg_stat_statements,powa,pg_qualstats,pg_stat_kcache'" >> $PGDATA/postgresql.conf
+echo "listen_addresses = '*'" >> $PGDATA/postgresql.conf
 
 # restart pg
-gosu postgres pg_ctl -D "$PGDATA" -w stop -m fast
-gosu postgres pg_ctl -D "$PGDATA" -w start
+pg_ctl -D "$PGDATA" -w stop -m fast
+pg_ctl -D "$PGDATA" -w start
 
-gosu postgres psql -f /usr/local/src/install_all.sql
+psql -f /usr/local/src/install_all.sql


### PR DESCRIPTION
This fixes broken links to github repos for the powa related project.
It also gets rid of `gosu` which is not required anymore.